### PR TITLE
Refine CLI export and README documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,17 +23,18 @@ go build -o bin/wordsdk ./cli
 Export translations to [Fluent](https://projectfluent.org/) FTL files:
 
 ```bash
-bin/wordsdk export --api-key <API_KEY>
+bin/wordsdk export --api-key <API_KEY> [--dynamic-key <KEY>]
 ```
 
 Options:
 
 - `--api-key` (required) – API key used to authenticate.
+- `--dynamic-key` – export dynamic translations for the provided key instead of static ones.
 - `--environment` – target API environment (`production` or `stage`, default `production`).
-- `--output`, `-o` – destination directory for generated files (default `.`).
+- `--output`, `-o` – destination directory for generated files (default `./exported`).
 
 Instead of building you can run the CLI directly:
 
 ```bash
-go run ./cli export --api-key <API_KEY>
+go run ./cli export --api-key <API_KEY> [--dynamic-key <KEY>]
 ```

--- a/cli/export.go
+++ b/cli/export.go
@@ -53,10 +53,6 @@ var exportCmd = &cobra.Command{
 			}
 		}
 
-		for i, datum := range data {
-			fmt.Println(i, datum)
-		}
-
 		err = exportObjectsToFTLFiles(data, outDir, path)
 		if err != nil {
 			return fmt.Errorf("failed to export translations: %w", err)


### PR DESCRIPTION
## Summary
- remove debug dumping of translations from `export` CLI command
- document `--dynamic-key` flag and correct default output dir in README

## Testing
- `go vet ./...` *(fails: command hung, interrupted)*
- `go test ./...` *(fails: connection refused and other failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a46900ce10832f97a598eccc5628cc