### PR TITLE
feat(cli): support environment variables for configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,15 @@ Options:
 - `--environment` – target API environment (`production` or `stage`, default `production`).
 - `--output`, `-o` – destination directory for generated files (default `./exported`).
 
+These options can also be supplied via environment variables. If both a flag and an environment variable are provided, the flag takes precedence.
+
+| Flag          | Environment variable   |
+|---------------|------------------------|
+| `--api-key`   | `WORDSDK_API_KEY`      |
+| `--dynamic-key` | `WORDSDK_DYNAMIC_KEY` |
+| `--environment` | `WORDSDK_ENVIRONMENT` |
+| `--output`    | `WORDSDK_OUTPUT`       |
+
 Instead of building you can run the CLI directly:
 
 ```bash

--- a/cli/main.go
+++ b/cli/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"os"
+
 	"github.com/spf13/cobra"
 )
 
@@ -15,8 +17,15 @@ var rootCmd = &cobra.Command{
 }
 
 func init() {
-	rootCmd.PersistentFlags().String("api-key", "", "API key")
-	rootCmd.PersistentFlags().String("dynamic-key", "", "Dynamic key for fetching dynamic translations")
-	rootCmd.PersistentFlags().String("environment", "production", "API environment: production or stage")
-	rootCmd.PersistentFlags().StringP("output", "o", "./exported", "Output directory")
+	rootCmd.PersistentFlags().String("api-key", getenv("WORDSDK_API_KEY", ""), "API key")
+	rootCmd.PersistentFlags().String("dynamic-key", getenv("WORDSDK_DYNAMIC_KEY", ""), "Dynamic key for fetching dynamic translations")
+	rootCmd.PersistentFlags().String("environment", getenv("WORDSDK_ENVIRONMENT", "production"), "API environment: production or stage")
+	rootCmd.PersistentFlags().StringP("output", "o", getenv("WORDSDK_OUTPUT", "./exported"), "Output directory")
+}
+
+func getenv(key, fallback string) string {
+	if v, ok := os.LookupEnv(key); ok {
+		return v
+	}
+	return fallback
 }


### PR DESCRIPTION
## Summary
- allow CLI flags to be configured via WORDSDK_* environment variables
- document available environment variables in README

## Testing
- `go test` *(fails: src.LoadAllStatic undefined)*
- `go build` *(fails: src.LoadAllStatic undefined)*

------
https://chatgpt.com/codex/tasks/task_e_68a48ea79054832fb850f59231108caa